### PR TITLE
Update Dockerfile

### DIFF
--- a/external-auth-tests/Dockerfile
+++ b/external-auth-tests/Dockerfile
@@ -1,3 +1,3 @@
 FROM opensuse/leap:15.0
 
-RUN zypper in ref && zypper in -y python-tox
+RUN zypper ref && zypper in -y python-tox


### PR DESCRIPTION
Should just be `zypper refresh`.  Though it technically still works with `install refresh`, what actually happens is the repos are refreshed because the base image has the cache emptied, so zypper gets the cache before it tries to install a package named `ref`. :)